### PR TITLE
Upgrade ureq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ rustls = { version = "*", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
-ureq = { version = "=2.1.0", features = ["json"], optional = true }
+ureq = { version = "2.9.7", features = ["json"], optional = true }
 webpki-roots = { version = "0.26", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ hyper-rustls = { version = "0.26.0", optional = true }
 hyper-util = { version = "0.1.2", features = ["client-legacy", "http1", "tokio"], optional = true }
 once_cell = "1"
 regex = { version = "1" }
-# Version set by hyper-rustls
-rustls = { version = "*", optional = true }
+# This needs to be aligned with hyper-rustls, make sure we don't end up with two copies if we update either.
+rustls = { version = "0.22.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"


### PR DESCRIPTION
Ureq was being held back for minimum rust versions, but limitation has been lifted in Umar.